### PR TITLE
Replace deprecated function

### DIFF
--- a/preconditions.py
+++ b/preconditions.py
@@ -20,8 +20,8 @@ def preconditions(*precs):
 
     precinfo = []
     for p in precs:
-        spec = inspect.getargspec(p)
-        if spec.varargs or spec.keywords:
+        spec = inspect.getfullargspec(p)
+        if spec.varargs or spec.varkw:
             raise PreconditionError(
                 ('Invalid precondition must not accept * nor ** args:\n' +
                  '  {!s}\n')
@@ -35,7 +35,7 @@ def preconditions(*precs):
         precinfo.append( (appargs, closureargs, p) )
 
     def decorate(f):
-        fspec = inspect.getargspec(f)
+        fspec = inspect.getfullargspec(f)
 
         for (appargs, closureargs, p) in precinfo:
             for apparg in appargs:
@@ -71,7 +71,7 @@ def preconditions(*precs):
                             inspect.formatargvalues(
                                 fspec.args,
                                 fspec.varargs,
-                                fspec.keywords,
+                                fspec.varkw,
                                 args),
                             stripped_source(p)))
 


### PR DESCRIPTION
Response to:
     DeprecationWarning: inspect.getargspec() is deprecated, use inspect.signature() or inspect.getfullargspec()